### PR TITLE
Update build.gradle

### DIFF
--- a/packages/flutter_bluetooth_printer/android/build.gradle
+++ b/packages/flutter_bluetooth_printer/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'id.flutter.plugins.flutter_bluetooth_printer'
     compileSdkVersion 31
 
     compileOptions {

--- a/packages/flutter_bluetooth_printer/pubspec.yaml
+++ b/packages/flutter_bluetooth_printer/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   image: ">=4.1.7"
   flutter_bluetooth_printer_platform_interface: ^0.0.5
   plugin_platform_interface: ^2.1.2
-  flutter_bluetooth_printer_macos: ^1.1.1
+  flutter_bluetooth_printer_macos: any
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/flutter_bluetooth_printer/pubspec.yaml
+++ b/packages/flutter_bluetooth_printer/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   image: ">=4.1.7"
   flutter_bluetooth_printer_platform_interface: ^0.0.5
   plugin_platform_interface: ^2.1.2
-  flutter_bluetooth_printer_macos: any
+  # flutter_bluetooth_printer_macos: any
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/flutter_bluetooth_printer_macos/pubspec.yaml
+++ b/packages/flutter_bluetooth_printer_macos/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.1.1
 repository: https://github.com/ekasetiawans/flutter_bluetooth_printer_plugin
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.2.6 <4.0.0"
+  flutter: ">=3.2.6"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Fix of 
A problem occurred configuring project ':flutter_bluetooth_printer'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Please specify a namespace in the module's build.gradle file like so:

     android {
         namespace 'com.example.namespace'
     }