### PR TITLE
Update build.gradle

### DIFF
--- a/packages/flutter_bluetooth_printer/android/build.gradle
+++ b/packages/flutter_bluetooth_printer/android/build.gradle
@@ -22,6 +22,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+
+    namespace 'id.flutter.plugins.flutter_bluetooth_printer'
+    
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
Fix for:

Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Please specify a namespace in the module's build.gradle file like so:

     android {
         namespace 'com.example.namespace'
     }